### PR TITLE
downgrade logback

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val library =
       )
 
     val logback = Seq(
-      "ch.qos.logback"             % "logback-classic"               % "1.2.3"            % Compile
+      "ch.qos.logback"             % "logback-classic"               % "1.1.11"            % Compile
     )
 
     val joda = Seq(
@@ -90,7 +90,7 @@ lazy val settings =
 lazy val commonSettings =
   Seq(
     //version := "0.1.14", //automatically calculated by sbt-git
-    //scalaVersion := "2.11.11", // taken from .travis.yml via sbt-travisci
+    scalaVersion := "2.11.11", // taken from .travis.yml via sbt-travisci
     organization := "com.weightwatchers",
     mappings.in(Compile, packageBin) += baseDirectory.in(ThisBuild).value / "LICENSE" -> "LICENSE",
     scalacOptions ++= Seq( //http://tpolecat.github.io/2017/04/25/scalac-flags.html

--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ lazy val settings =
 lazy val commonSettings =
   Seq(
     //version := "0.1.14", //automatically calculated by sbt-git
-    scalaVersion := "2.11.11", // taken from .travis.yml via sbt-travisci
+    //scalaVersion := "2.11.11", // taken from .travis.yml via sbt-travisci
     organization := "com.weightwatchers",
     mappings.in(Compile, packageBin) += baseDirectory.in(ThisBuild).value / "LICENSE" -> "LICENSE",
     scalacOptions ++= Seq( //http://tpolecat.github.io/2017/04/25/scalac-flags.html


### PR DESCRIPTION
The latest version of logback caused issue with far too many other libraries. Downgrade to the latest widely supported version, `1.1.11`