### PR TITLE
fix Kinesis Endpoint,Port values

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -127,7 +127,7 @@ kinesis {
          # connects with TLS.
          #
          # Expected pattern: ^([A-Za-z0-9-\\.]+)?$
-         # CustomEndpoint =
+         # KinesisEndpoint =
 
          # If true, throttled puts are not retried. The records that got throttled
          # will be failed immediately upon receiving the throttling error. This is
@@ -236,12 +236,12 @@ kinesis {
          # Maximum (inclusive): 16
          MinConnections = 1
 
-         # Server port to connect to. Only useful with custom_endpoint.
+         # Server port to connect to. Only useful with KinesisEndpoint.
          #
          # Default: 443
          # Minimum: 1
          # Maximum (inclusive): 65535
-         Port = 443
+         KinesisPort = 443
 
          # Limits the maximum allowed put rate for a shard, as a percentage of the
          # backend limits.


### PR DESCRIPTION
@agaro1121  could you double check this change?
Related to https://github.com/WW-Digital/reactive-kinesis/issues/11
Avoid messages:
- [warn] c.a.s.k.p.KinesisProducerConfiguration - Property Port ignored as there is no corresponding set method in KinesisProducerConfiguration
-  [warn] c.a.s.k.p.KinesisProducerConfiguration - Property CustomEndpoint ignored as there is no corresponding set method in KinesisProducerConfiguration
