### PR TITLE
Fix #25 by providing an Akka Stream Source graph stage for Kinesis.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,7 @@ lazy val library =
     val lightbend = Seq(
       "com.typesafe"               % "config"                        % "1.3.1"            % Compile,
       "com.typesafe.akka"          %% "akka-actor"                   % Version.akka       % Compile,
+      "com.typesafe.akka"          %% "akka-stream"                  % Version.akka       % Compile,
       "com.typesafe.scala-logging" %% "scala-logging"                % "3.5.0"            % Compile
       )
 
@@ -68,15 +69,15 @@ lazy val library =
       "org.scalactic"              %% "scalactic"                    % Version.scalaTest  % Compile)
 
     val testing = Seq(
-      "org.scalatest"              %% "scalatest"                    % Version.scalaTest  % Test,
-      "org.scalacheck"             %% "scalacheck"                   % Version.scalaCheck % Test,
-      "com.typesafe.akka"          %% "akka-testkit"                 % Version.akka       % Test,
-      "org.mockito"                % "mockito-core"                  % "2.7.15"           % Test,
-      "io.kamon"                   %% "kamon-core"                   % Version.kamon      % Test,
-      "io.kamon"                   %% "kamon-akka-2.4"               % Version.kamon      % Test,
-      "io.kamon"                   %% "kamon-statsd"                 % Version.kamon      % Test,
-      "io.kamon"                   %% "kamon-log-reporter"           % Version.kamon      % Test,
-      "io.kamon"                   %% "kamon-system-metrics"         % Version.kamon      % Test
+      "org.scalatest"              %% "scalatest"                    % Version.scalaTest  % "it,test",
+      "org.scalacheck"             %% "scalacheck"                   % Version.scalaCheck % "it,test",
+      "com.typesafe.akka"          %% "akka-testkit"                 % Version.akka       % "it,test",
+      "org.mockito"                % "mockito-core"                  % "2.7.15"           % "it,test",
+      "io.kamon"                   %% "kamon-core"                   % Version.kamon      % "it,test",
+      "io.kamon"                   %% "kamon-akka-2.4"               % Version.kamon      % "it,test",
+      "io.kamon"                   %% "kamon-statsd"                 % Version.kamon      % "it,test",
+      "io.kamon"                   %% "kamon-log-reporter"           % Version.kamon      % "it,test",
+      "io.kamon"                   %% "kamon-system-metrics"         % Version.kamon      % "it,test"
     )
   }
 

--- a/src/it/resources/sample.conf
+++ b/src/it/resources/sample.conf
@@ -26,6 +26,29 @@ kinesis {
    testConsumer {
       # The name of the consumer stream, MUST be specified per consumer
       stream-name = "test-kinesis-reliability"
+
+      # Use localstack for integration test
+      kcl {
+         kinesisEndpoint = "http://localhost:4568"
+         dynamoDBEndpoint = "http://localhost:4569"
+
+         # dramatically reduce default values.
+         # This will speed up the integration test by factor 20x or greater
+         maxRecords = 100
+         metricsLevel = NONE
+         failoverTimeMillis = 500
+         shardSyncIntervalMillis = 1000
+         idleTimeBetweenReadsInMillis = 100
+         parentShardPollIntervalMillis = 1000
+      }
+
+      worker {
+         batchTimeoutSeconds = 1
+         failedMessageRetries = 0
+         failureTolerancePercentage = 0
+         gracefulShutdownHook = false
+         shutdownTimeoutSeconds = 10
+      }
    }
 
    ## Test specific properties

--- a/src/it/scala/com/weightwatchers/reactive.kinesis/AkkaUnitTestLike.scala
+++ b/src/it/scala/com/weightwatchers/reactive.kinesis/AkkaUnitTestLike.scala
@@ -1,0 +1,31 @@
+package com.weightwatchers.reactive.kinesis
+
+import akka.actor.{ActorSystem, Scheduler}
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.testkit.TestKitBase
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+import scala.concurrent.ExecutionContextExecutor
+
+
+/**
+  * Use this test trait for akka based tests.
+  * An akka system is started and cleaned up automatically.
+  */
+trait AkkaUnitTestLike extends TestKitBase with ScalaFutures with BeforeAndAfterAll { self: Suite =>
+
+  implicit lazy val config: Config = ConfigFactory.load("sample.conf")
+  implicit lazy val system: ActorSystem = ActorSystem(suiteName, config)
+  implicit lazy val scheduler: Scheduler = system.scheduler
+  implicit lazy val mat: Materializer = ActorMaterializer()
+  implicit lazy val ctx: ExecutionContextExecutor = system.dispatcher
+
+  abstract override def afterAll(): Unit = {
+    super.afterAll()
+    // intentionally shutdown the actor system last.
+    system.terminate().futureValue
+  }
+}
+

--- a/src/it/scala/com/weightwatchers/reactive.kinesis/AkkaUnitTestLike.scala
+++ b/src/it/scala/com/weightwatchers/reactive.kinesis/AkkaUnitTestLike.scala
@@ -9,17 +9,17 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 
 import scala.concurrent.ExecutionContextExecutor
 
-
 /**
   * Use this test trait for akka based tests.
   * An akka system is started and cleaned up automatically.
   */
-trait AkkaUnitTestLike extends TestKitBase with ScalaFutures with BeforeAndAfterAll { self: Suite =>
+trait AkkaUnitTestLike extends TestKitBase with ScalaFutures with BeforeAndAfterAll {
+  self: Suite =>
 
-  implicit lazy val config: Config = ConfigFactory.load("sample.conf")
-  implicit lazy val system: ActorSystem = ActorSystem(suiteName, config)
-  implicit lazy val scheduler: Scheduler = system.scheduler
-  implicit lazy val mat: Materializer = ActorMaterializer()
+  implicit lazy val config: Config                = ConfigFactory.load("sample.conf")
+  implicit lazy val system: ActorSystem           = ActorSystem(suiteName, config)
+  implicit lazy val scheduler: Scheduler          = system.scheduler
+  implicit lazy val mat: Materializer             = ActorMaterializer()
   implicit lazy val ctx: ExecutionContextExecutor = system.dispatcher
 
   abstract override def afterAll(): Unit = {
@@ -28,4 +28,3 @@ trait AkkaUnitTestLike extends TestKitBase with ScalaFutures with BeforeAndAfter
     system.terminate().futureValue
   }
 }
-

--- a/src/it/scala/com/weightwatchers/reactive.kinesis/KinesisKit.scala
+++ b/src/it/scala/com/weightwatchers/reactive.kinesis/KinesisKit.scala
@@ -1,0 +1,161 @@
+package com.weightwatchers.reactive.kinesis
+
+import java.nio.ByteBuffer
+
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBClientBuilder}
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration
+import com.amazonaws.services.kinesis.model.PutRecordRequest
+import com.amazonaws.services.kinesis.{AmazonKinesisAsync, AmazonKinesisAsyncClientBuilder}
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Suite}
+
+import scala.collection.JavaConverters._
+
+/**
+  * Base trait to create a KinesisConfiguration from application config + override options.
+  */
+trait KinesisConfiguration {
+
+  // The global application config
+  def config: Config
+
+  def consumerConfig(appName: String, workerId: String, batchSize: Int): ConsumerConf = {
+    val conf = ConsumerConf(config.getConfig("kinesis"), "testConsumer")
+    val kcl = conf.kclConfiguration
+    conf.copy(
+      kclConfiguration = new KinesisClientLibConfiguration(
+        appName,
+        kcl.getStreamName,
+        kcl.getKinesisCredentialsProvider,
+        workerId)
+        .withKinesisEndpoint(kcl.getKinesisEndpoint)
+        .withDynamoDBEndpoint(kcl.getDynamoDBEndpoint)
+        .withMetricsLevel(kcl.getMetricsLevel)
+        .withMaxRecords(batchSize)
+        .withCallProcessRecordsEvenForEmptyRecordList(kcl.shouldCallProcessRecordsEvenForEmptyRecordList())
+        .withCleanupLeasesUponShardCompletion(kcl.shouldCleanupLeasesUponShardCompletion())
+        .withFailoverTimeMillis(kcl.getFailoverTimeMillis)
+        .withIdleTimeBetweenReadsInMillis(kcl.getIdleTimeBetweenReadsInMillis)
+        .withInitialLeaseTableReadCapacity(kcl.getInitialLeaseTableReadCapacity)
+        .withInitialLeaseTableWriteCapacity(kcl.getInitialLeaseTableWriteCapacity)
+        .withInitialPositionInStream(kcl.getInitialPositionInStream)
+        .withMaxLeaseRenewalThreads(kcl.getMaxLeaseRenewalThreads)
+        .withMaxLeasesForWorker(kcl.getMaxLeasesForWorker)
+        .withMaxLeasesToStealAtOneTime(kcl.getMaxLeasesToStealAtOneTime)
+        .withMetricsBufferTimeMillis(kcl.getMetricsBufferTimeMillis)
+        .withParentShardPollIntervalMillis(kcl.getParentShardPollIntervalMillis)
+        .withShardSyncIntervalMillis(kcl.getShardSyncIntervalMillis)
+        .withShardPrioritizationStrategy(kcl.getShardPrioritizationStrategy)
+        .withSkipShardSyncAtStartupIfLeasesExist(kcl.getSkipShardSyncAtWorkerInitializationIfLeasesExist)
+        .withTaskBackoffTimeMillis(kcl.getTaskBackoffTimeMillis)
+        .withValidateSequenceNumberBeforeCheckpointing(kcl.shouldValidateSequenceNumberBeforeCheckpointing())
+    )
+  }
+}
+
+/**
+  * Use this trait to interact with Kinesis.
+  * Every suite will have a clean Kinesis and Dynamo as well as one Stream with 2 Shards with 100 Messages each.
+  */
+trait KinesisKit extends BeforeAndAfter with BeforeAndAfterAll with StrictLogging with KinesisConfiguration {
+  self: Suite =>
+
+  val TestStreamNrOfMessagesPerShard: Long = 100
+  val TestStreamNumberOfShards: Long = 2
+  val TestStreamName: String = "test-kinesis-reliability"
+
+  /**
+    * Cleanup dynamo before each test
+    */
+  before {
+    cleanDynamo()
+  }
+
+  override protected def beforeAll(): Unit = {
+    val kinesis = kinesisClient()
+
+    // clean up from eventually last run
+    cleanKinesis(kinesis)
+
+    // create new stream
+    createKinesisStream(kinesis)
+
+    // Pumping test data inside.
+    createTestData(TestStreamNrOfMessagesPerShard.toInt, kinesis)
+
+    kinesis.shutdown()
+  }
+
+  protected def createKinesisStream(kinesisClient: AmazonKinesisAsync): Unit = {
+
+    kinesisClient.createStream(TestStreamName, TestStreamNumberOfShards.toInt)
+
+    // Block until the stream is ready to rumble.
+    while (kinesisClient.describeStream(TestStreamName).getStreamDescription.getStreamStatus != "ACTIVE") {
+      Thread.sleep(100)
+    }
+    logger.info(s"Stream: $TestStreamName is created.")
+  }
+
+  protected def cleanKinesis(kinesisClient: AmazonKinesisAsync): Unit = {
+    // We delete our stream if it exist.
+    kinesisClient.listStreams().getStreamNames.asScala.toList.find(_ == TestStreamName).foreach {
+      kinesisClient.deleteStream
+    }
+
+    // Blocking until it is really deleted.
+    while (kinesisClient.listStreams().getStreamNames.contains(TestStreamName)) {
+      Thread.sleep(100)
+    }
+  }
+
+  protected def cleanDynamo(): Unit = {
+    val dynamo = dynamoClient()
+    cleanDynamo(dynamo)
+    dynamo.shutdown()
+  }
+
+  protected def cleanDynamo(dynamoClient: AmazonDynamoDB): Unit = {
+    val result = dynamoClient.listTables()
+    result.getTableNames.asScala.foreach { tableName =>
+      logger.info(s"Delete dynamo table $tableName")
+      dynamoClient.deleteTable(tableName)
+    }
+  }
+
+  protected def kinesisClient(): AmazonKinesisAsync = {
+    val kcl = consumerConfig(suiteName, "setup", batchSize = 1000).kclConfiguration
+    AmazonKinesisAsyncClientBuilder.standard()
+      .withClientConfiguration(kcl.getKinesisClientConfiguration)
+      .withEndpointConfiguration(new EndpointConfiguration(kcl.getKinesisEndpoint, kcl.getRegionName))
+      .build()
+  }
+
+  protected def dynamoClient(): AmazonDynamoDB = {
+    val kcl = consumerConfig(suiteName, "setup", batchSize = 1000).kclConfiguration
+    AmazonDynamoDBClientBuilder.standard()
+      .withClientConfiguration(kcl.getDynamoDBClientConfiguration)
+      .withEndpointConfiguration(new EndpointConfiguration(kcl.getDynamoDBEndpoint, kcl.getRegionName))
+      .build()
+  }
+
+  protected def createTestData(testDataCount: Int, client: AmazonKinesisAsync): Unit = {
+    import scala.collection.JavaConverters._
+
+    client
+      .describeStream(TestStreamName)
+      .getStreamDescription.getShards.asScala.toList.map(_.getShardId)
+      .foreach { shardId =>
+        (1 to testDataCount).foreach { nr =>
+          val msg = new PutRecordRequest()
+            .withData(ByteBuffer.wrap(nr.toString.getBytes))
+            .withStreamName(TestStreamName)
+            .withPartitionKey(shardId)
+          client.putRecord(msg)
+        }
+      }
+  }
+}

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceTest.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceTest.scala
@@ -1,0 +1,133 @@
+package com.weightwatchers.reactive.kinesis.stream
+
+import akka.stream.scaladsl.Sink
+import com.weightwatchers.reactive.kinesis.{AkkaUnitTestLike, KinesisKit}
+import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
+import org.scalatest._
+
+import scala.concurrent.duration._
+
+class KinesisSourceTest extends WordSpec with KinesisKit with AkkaUnitTestLike with Matchers {
+
+  "A Kinesis Source" should {
+
+    "process all messages of a stream with one worker" in new WithKinesis {
+      val appName = "1worker"
+      val result = Kinesis.source(consumerConf = consumerConf(appName, TestStreamNrOfMessagesPerShard))
+        .take(TestStreamNumberOfShards * TestStreamNrOfMessagesPerShard)
+        .map { event =>
+          event.commit()
+          event.event.payload
+        }.runWith(Sink.seq)
+
+      val grouped = result.futureValue.groupBy(identity)
+      result.futureValue.distinct should have size TestStreamNrOfMessagesPerShard
+      grouped should have size TestStreamNrOfMessagesPerShard
+      grouped.values.foreach(_ should have size TestStreamNumberOfShards)
+    }
+
+    "process all messages of a stream with 2 workers" in new WithKinesis {
+      // Please note: since source1 and source2 are started simultaneously, both will assume there is no other worker.
+      // During register one will fail and not read any message until retry
+      // Depending on timing one or both sources will read all events
+      val appName = "2worker"
+      val batchSize = TestStreamNrOfMessagesPerShard
+      val source1 = Kinesis.source(consumerConf = consumerConf(appName, batchSize))
+      val source2 = Kinesis.source(consumerConf = consumerConf(appName, batchSize))
+      val result = source1
+        .merge(source2)
+        .take(TestStreamNrOfMessagesPerShard * TestStreamNumberOfShards)
+        .map { event =>
+          event.commit()
+          event.event.payload
+        }.runWith(Sink.seq)
+
+      val grouped = result.futureValue.groupBy(identity)
+      result.futureValue.distinct should have size TestStreamNrOfMessagesPerShard
+      grouped should have size TestStreamNrOfMessagesPerShard
+      grouped.values.foreach(_ should have size TestStreamNumberOfShards)
+    }
+
+    "process all messages of a stream with 4 workers" in new WithKinesis {
+      // Please note: since all sources are started simultaneously, all will assume there is no other worker.
+      // During register all except one will fail and not read any message until retry
+      // Depending on timing one or multiple sources will read all events
+      val batchSize = TestStreamNrOfMessagesPerShard
+      val appName = "4worker"
+      val source1 = Kinesis.source(consumerConf = consumerConf(appName, batchSize))
+      val source2 = Kinesis.source(consumerConf = consumerConf(appName, batchSize))
+      val source3 = Kinesis.source(consumerConf = consumerConf(appName, batchSize))
+      val source4 = Kinesis.source(consumerConf = consumerConf(appName, batchSize))
+      val result = source1.merge(source2).merge(source3).merge(source4)
+        // Since only 2 clients can take batchSize messages, an overall take is needed here to end the stream
+        .take(TestStreamNrOfMessagesPerShard * TestStreamNumberOfShards)
+        .map { event =>
+          event.commit()
+          event.event.payload
+        }.runWith(Sink.seq)
+
+      val grouped = result.futureValue.groupBy(identity)
+      result.futureValue.distinct should have size TestStreamNrOfMessagesPerShard
+      grouped should have size TestStreamNrOfMessagesPerShard
+      grouped.values.foreach(_ should have size TestStreamNumberOfShards)
+    }
+
+    "maintain the read position in the stream correctly" in new WithKinesis {
+      val batchSize = TestStreamNrOfMessagesPerShard / 2 // 2 * NrOfShards batches needed
+      val appName = "stream_read_position"
+
+      // We create multiple Sources (one after the other!). Each source:
+      // - takes batchSize of messages and commits all of them
+      // - dies after one batch
+      // We expect to get all messages by n reads (which means, that the read position was stored correctly)
+      val result = for (_ <- 1.to((TestStreamNumberOfShards * TestStreamNrOfMessagesPerShard / batchSize).toInt)) yield {
+        Kinesis.source(consumerConf = consumerConf(appName, batchSize)).take(batchSize)
+          .map { event =>
+            event.commit()
+            event.event.payload
+          }.runWith(Sink.seq).futureValue
+      }
+
+      val allMessages = result.flatten
+
+      val grouped = allMessages.groupBy(identity)
+      allMessages.distinct should have size TestStreamNrOfMessagesPerShard
+      grouped should have size TestStreamNrOfMessagesPerShard
+    }
+
+    "not commit the position, if the event is not committed" in new WithKinesis {
+      val batchSize = TestStreamNrOfMessagesPerShard / 2 // 2 * NrOfShards batches needed
+      val appName = "stream_not_commited"
+
+      // This worker will read batchSize events and will not commit
+      // We expect that the read position will not change
+      val uncomitted = Kinesis.source(consumerConf(appName, batchSize = batchSize))
+        .take(batchSize)
+        .runWith(Sink.seq).futureValue
+
+      // This worker will read all available events.
+      // This works only, if the first worker has not committed anything
+      val commited = Kinesis.source(consumerConf = consumerConf(appName, batchSize = batchSize))
+        .take(TestStreamNumberOfShards * TestStreamNrOfMessagesPerShard)
+        .map { event =>
+          event.commit()
+          event.event.payload
+        }.runWith(Sink.seq).futureValue
+
+      uncomitted should have size batchSize
+      val grouped = commited.groupBy(identity)
+      commited.distinct should have size TestStreamNrOfMessagesPerShard
+      grouped should have size TestStreamNrOfMessagesPerShard
+      grouped.values.foreach(_ should have size TestStreamNumberOfShards)
+    }
+  }
+
+  class WithKinesis {
+    val workerIdGen: Iterator[String] = 1.to(Int.MaxValue).iterator.map(id => s"wrk-$id")
+    def consumerConf(appName: String, batchSize: Long): ConsumerConf = {
+      consumerConfig(appName, appName + "-" + workerIdGen.next(), batchSize.toInt)
+    }
+  }
+
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(60.seconds)
+}

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/stream/Kinesis.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/stream/Kinesis.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 WeightWatchers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.weightwatchers.reactive.kinesis.stream
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
+import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
+
+/**
+  * Main entry point for creating a Kinesis source and sink.
+  */
+object Kinesis {
+
+  /**
+    * Create a source, that provides KinesisEvents.
+    * Please note: every KinesisEvent has to be committed during the user flow!
+    * Uncommitted events will be retransmitted after a timeout.
+    *
+    * @param consumerConf the configuration to connect to Kinesis.
+    * @param system the actor system.
+    * @return A source of KinesisEvent objects.
+    */
+  def source(
+      consumerConf: ConsumerConf
+  )(implicit system: ActorSystem): Source[KinesisEvent, NotUsed] = {
+    Source.fromGraph(new KinesisSourceGraph(consumerConf, system))
+  }
+
+  /**
+    * Create a source by using the actor system configuration, that provides KinesisEvents.
+    * Please note: every KinesisEvent has to be committed during the user flow!
+    * Uncommitted events will be retransmitted after a timeout.
+    *
+    * The application conf file should look like this:
+    * {{{
+    * kinesis {
+    *    application-name = "SampleService"
+    *    consumer-name {
+    *       stream-name = "sample-consumer"
+    *    }
+    * }
+    * }}}
+    * See kinesis reference.conf for a list of all available config options.
+    *
+    * @param consumerName the name of the consumer in the application.conf.
+    * @param inConfig the name of the sub-config for kinesis.
+    * @param system the actor system to use.
+    * @return A source of KinesisEvent objects.
+    */
+  def source(consumerName: String, inConfig: String = "kinesis")(
+      implicit system: ActorSystem
+  ): Source[KinesisEvent, NotUsed] = {
+    source(ConsumerConf(system.settings.config.getConfig(inConfig), consumerName))
+  }
+}

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceGraph.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceGraph.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017 WeightWatchers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.weightwatchers.reactive.kinesis.stream
+
+import akka.Done
+import akka.actor.Actor.Receive
+import akka.actor.Status.Failure
+import akka.actor.{ActorRef, ActorSystem}
+import akka.pattern.pipe
+import akka.stream.stage.{GraphStage, GraphStageLogic, OutHandler}
+import akka.stream.{Attributes, BufferOverflowException, Outlet, SourceShape}
+import com.typesafe.scalalogging.LazyLogging
+import com.weightwatchers.reactive.kinesis.consumer.ConsumerWorker.{
+  ConsumerShutdown,
+  ConsumerWorkerFailure,
+  EventProcessed,
+  ProcessEvent
+}
+import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer
+import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
+import com.weightwatchers.reactive.kinesis.models.ConsumerEvent
+
+/**
+  * The KinesisEvent is passed through the stream.
+  * Every event has to be committed explicitly.
+  */
+sealed trait KinesisEvent {
+  def event: ConsumerEvent
+  def commit(successful: Boolean = true): KinesisEvent
+}
+
+/**
+  * Actor based implementation of KinesisEvent.
+  */
+private[kinesis] case class KinesisActorEvent(event: ConsumerEvent)(implicit sender: ActorRef)
+    extends KinesisEvent {
+  def commit(successful: Boolean = true): KinesisEvent = {
+    sender ! EventProcessed(event.sequenceNumber, successful)
+    this
+  }
+}
+
+/**
+  * A KinesisSourceGraph will attach to a kinesis stream with the provided configuration and constitute a Source[KinesisEvent, NotUsed].
+  * Usage:
+  * {{{
+  *   val config = ConfigFactory.load()
+  *   val consumerConfig = ConsumerConf(config.getConfig("kinesis"), "some-consumer")
+  *   val source = Source.fromGraph(new KinesisSourceGraph(consumerConf, system))
+  * }}}
+  * Assuming a configuration file like this:
+  * {{{
+  * kinesis {
+  *    application-name = "SampleService"
+  *    some-consumer {
+  *       stream-name = "sample-consumer"
+  *    }
+  * }
+  * }}}
+  * See reference.conf for a list of all available config options.
+  *
+  * @param config the kinesis stream configuration.
+  * @param actorSystem the actor system.
+  */
+class KinesisSourceGraph(config: ConsumerConf, actorSystem: ActorSystem)
+    extends GraphStage[SourceShape[KinesisEvent]]
+    with LazyLogging {
+
+  private[this] val out: Outlet[KinesisEvent]   = Outlet("KinesisSource.out")
+  override val shape: SourceShape[KinesisEvent] = SourceShape.of(out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) {
+      // KCL will read events in batches. The stream should be able to buffer the whole batch.
+      private[this] val bufferSize: Int = config.kclConfiguration.getMaxRecords
+      // The queue to buffer events that can not be pushed downstream.
+      private[this] val messages = new java.util.ArrayDeque[KinesisEvent]()
+      // The kinesis consumer to read from.
+      private[this] var kinesisConsumer: Option[KinesisConsumer] = None
+
+      setHandler(out, new OutHandler {
+        override def onPull(): Unit = if (!messages.isEmpty) push(out, messages.poll())
+      })
+
+      override def preStart(): Unit = {
+        super.preStart()
+        // the underlying stage actor reference of this graph stage.
+        val actor    = getStageActor(receive).ref
+        val consumer = KinesisConsumer(config, actor, actorSystem)
+        // start() creates a long running future that returns, if the consumer worker is done or failed.
+        import actorSystem.dispatcher
+        consumer.start().map(_ => Done).pipeTo(actor)
+        kinesisConsumer = Some(consumer)
+      }
+
+      override def postStop(): Unit = {
+        logger.info(s"Stopping Source $out. ${messages.size()} messages are buffered unprocessed.")
+        kinesisConsumer.foreach(_.stop())
+        super.postStop()
+      }
+
+      def receive: Receive = {
+        case (_, _: ProcessEvent) if messages.size > bufferSize =>
+          // The messages are processed not fast enough, so the messages in the buffer exceeds the maximum buffersize
+          // Fail the stage to prevent message overflow.
+          // Ideally we could control when the next batch is fetched.
+          logger.warn(s"Buffer of size $bufferSize is full. Fail the stream.")
+          failStage(BufferOverflowException(s"Buffer overflow (max capacity was: $bufferSize)!"))
+
+        case (actorRef: ActorRef, ProcessEvent(event)) =>
+          // A new event that needs to be processed.
+          // Always use the queue to guarantee the correct order of messages.
+          logger.info(s"Process event: $event")
+          messages.offer(KinesisActorEvent(event)(actorRef))
+          while (isAvailable(out) && !messages.isEmpty) push(out, messages.poll())
+
+        case (_, ConsumerShutdown(shardId)) =>
+          // A consumer shutdown occurs when another source is created and hence the Kinesis shards are rebalanced.
+          // This message is received, if the graceful shutdown is finalized.
+          // Once https://github.com/WW-Digital/reactive-kinesis/issues/32 is fixed, we should drop all buffered
+          // messages of this shard.
+          logger.info(s"Consumer shutdown for shard $shardId")
+
+        case (_, ConsumerWorkerFailure(failedEvents, shardId)) =>
+          // Send for all events of a batch, where the processing has failed (after configured retries)
+          // Since proceeding is not possible, the stream is failed.
+          logger.error(s"Consumer worker failure for shard $shardId")
+          failStage(
+            new IllegalStateException(s"Failed Events: $failedEvents for shardId: $shardId")
+          )
+
+        case (_, Done) =>
+          // The KinesisConsumer has been finished, so the stage is completed.
+          logger.info("Kinesis Consumer finished.")
+          completeStage()
+
+        case (_, Failure(ex)) =>
+          // The KinesisConsumer failed. This should also fail the stage.
+          logger.error("Kinesis Consumer failed", ex)
+          failStage(ex)
+      }
+    }
+}


### PR DESCRIPTION
This graph stage provides an akka source graph based on the actor model provided by the reactive kinesis consumer.

If a consumer is configured, an akka stream Source can be obtained via a simple `Kinesis.source("consumer-name")`.
Every message that flows through the stream needs to be committed explicitly.

An integration test is added that relies on [localstack](https://github.com/localstack/localstack) running on the same node (I did not add the localstack startup logic as part of this PR).

Steps to run the test:
1) Set this env var, since the localstack does not support CBOR: `export AWS_CBOR_DISABLE=true`
2) Start localstack (I use the docker-compose with: `docker-compose -f localstack.yml up`) in default configuration (Kinesis on port 4568, Dynamo on port 4569)
3) ```sbt it:test```

It was not as easy to come up with a good integration test, since a Kinesis Source usually never finishes. To have a finite test, I use `Flow.take` which ends the stream after a defined amount of entries. The interplay of different readers/shard consumers could be different between runs, but the test expectation should be met.
