### PR TITLE
Fix #33 by stopping the ConsumerWorker on lease loss

### DIFF
--- a/src/it/scala/com/weightwatchers/reactive/kinesis/common/KinesisSuite.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/common/KinesisSuite.scala
@@ -81,7 +81,7 @@ trait KinesisConfiguration {
            |      }
            |
            |      worker {
-           |         batchTimeoutSeconds = 2
+           |         batchTimeoutSeconds = 4
            |         failedMessageRetries = 0
            |         failureTolerancePercentage = 0
            |         gracefulShutdownHook = false

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManagerIntegrationSpec.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManagerIntegrationSpec.scala
@@ -3,7 +3,11 @@ package com.weightwatchers.reactive.kinesis.consumer
 import akka.actor.{ActorRef, Props}
 import akka.testkit.TestProbe
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessorFactory
-import com.weightwatchers.reactive.kinesis.common.{AkkaUnitTestLike, KinesisConfiguration, KinesisSuite}
+import com.weightwatchers.reactive.kinesis.common.{
+  AkkaUnitTestLike,
+  KinesisConfiguration,
+  KinesisSuite
+}
 import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FreeSpec, Matchers}
@@ -11,19 +15,22 @@ import org.scalatest.{FreeSpec, Matchers}
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 
-class ConsumerProcessingManagerIntegrationSpec extends FreeSpec
-  with KinesisSuite
-  with KinesisConfiguration
-  with AkkaUnitTestLike
-  with Matchers
-  with Eventually {
+class ConsumerProcessingManagerIntegrationSpec
+    extends FreeSpec
+    with KinesisSuite
+    with KinesisConfiguration
+    with AkkaUnitTestLike
+    with Matchers
+    with Eventually {
 
-  override def TestStreamNrOfMessagesPerShard: Long = 0
+  override def TestStreamNrOfMessagesPerShard: Long    = 0
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(60.seconds, 1.second)
 
   "A ConsumerProcessingManager on a stream with 2 shards" - {
 
-    "should start and stop processing managers correctly" in new withKinesisConfForApp("count_processing_managers") {
+    "should start and stop processing managers correctly" in new withKinesisConfForApp(
+      "count_processing_managers"
+    ) {
       // 2 consumers start - each operates on one shard
       val consumer1 = new TestKinesisConsumer(consumerConf(), TestProbe().testActor)
       val consumer2 = new TestKinesisConsumer(consumerConf(), TestProbe().testActor)
@@ -58,16 +65,19 @@ class ConsumerProcessingManagerIntegrationSpec extends FreeSpec
     }
   }
 
-  class TestKinesisConsumer(consumerConf: ConsumerConf,
-                            consumerWorkerProps: Props) extends KinesisConsumer(consumerConf, consumerWorkerProps, system, system) {
-    def this(consumerConf: ConsumerConf, eventProcessor: ActorRef) = this(consumerConf, ConsumerWorker.props(eventProcessor,
-      consumerConf.workerConf,
-      consumerConf.checkpointerConf,
-      consumerConf.dispatcher))
+  class TestKinesisConsumer(consumerConf: ConsumerConf, consumerWorkerProps: Props)
+      extends KinesisConsumer(consumerConf, consumerWorkerProps, system, system) {
+    def this(consumerConf: ConsumerConf, eventProcessor: ActorRef) =
+      this(consumerConf,
+           ConsumerWorker.props(eventProcessor,
+                                consumerConf.workerConf,
+                                consumerConf.checkpointerConf,
+                                consumerConf.dispatcher))
 
     val createdProcessingManager = ListBuffer.empty[ConsumerProcessingManager]
 
-    def runningProcessingManagers: Int = createdProcessingManager.count(_.shuttingDown.get == false)
+    def runningProcessingManagers: Int =
+      createdProcessingManager.count(_.shuttingDown.get == false)
 
     override private[consumer] val recordProcessorFactory: IRecordProcessorFactory = () => {
       val manager = new ConsumerProcessingManager(
@@ -84,5 +94,3 @@ class ConsumerProcessingManagerIntegrationSpec extends FreeSpec
     start()
   }
 }
-
-

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManagerIntegrationSpec.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManagerIntegrationSpec.scala
@@ -1,0 +1,88 @@
+package com.weightwatchers.reactive.kinesis.consumer
+
+import akka.actor.{ActorRef, Props}
+import akka.testkit.TestProbe
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessorFactory
+import com.weightwatchers.reactive.kinesis.common.{AkkaUnitTestLike, KinesisConfiguration, KinesisSuite}
+import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{FreeSpec, Matchers}
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.duration._
+
+class ConsumerProcessingManagerIntegrationSpec extends FreeSpec
+  with KinesisSuite
+  with KinesisConfiguration
+  with AkkaUnitTestLike
+  with Matchers
+  with Eventually {
+
+  override def TestStreamNrOfMessagesPerShard: Long = 0
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(60.seconds, 1.second)
+
+  "A ConsumerProcessingManager on a stream with 2 shards" - {
+
+    "should start and stop processing managers correctly" in new withKinesisConfForApp("count_processing_managers") {
+      // 2 consumers start - each operates on one shard
+      val consumer1 = new TestKinesisConsumer(consumerConf(), TestProbe().testActor)
+      val consumer2 = new TestKinesisConsumer(consumerConf(), TestProbe().testActor)
+      eventually {
+        consumer1.runningProcessingManagers shouldBe 1
+        consumer2.runningProcessingManagers shouldBe 1
+      }
+
+      // if consumer1 stops, consumer2 should start a shard worker
+      consumer1.stop()
+      eventually {
+        consumer1.runningProcessingManagers shouldBe 0
+        consumer2.runningProcessingManagers shouldBe 2
+      }
+
+      // if a new consumer joins, consumer2 should shutdown one shard, which is then taken over by consumer3
+      val consumer3 = new TestKinesisConsumer(consumerConf(), TestProbe().testActor)
+      eventually {
+        consumer1.runningProcessingManagers shouldBe 0
+        consumer2.runningProcessingManagers shouldBe 1
+        consumer3.runningProcessingManagers shouldBe 1
+      }
+
+      // if all consumers are stopped, all processing managers are shut down
+      consumer2.stop()
+      consumer3.stop()
+      eventually {
+        consumer1.runningProcessingManagers shouldBe 0
+        consumer2.runningProcessingManagers shouldBe 0
+        consumer3.runningProcessingManagers shouldBe 0
+      }
+    }
+  }
+
+  class TestKinesisConsumer(consumerConf: ConsumerConf,
+                            consumerWorkerProps: Props) extends KinesisConsumer(consumerConf, consumerWorkerProps, system, system) {
+    def this(consumerConf: ConsumerConf, eventProcessor: ActorRef) = this(consumerConf, ConsumerWorker.props(eventProcessor,
+      consumerConf.workerConf,
+      consumerConf.checkpointerConf,
+      consumerConf.dispatcher))
+
+    val createdProcessingManager = ListBuffer.empty[ConsumerProcessingManager]
+
+    def runningProcessingManagers: Int = createdProcessingManager.count(_.shuttingDown.get == false)
+
+    override private[consumer] val recordProcessorFactory: IRecordProcessorFactory = () => {
+      val manager = new ConsumerProcessingManager(
+        system.actorOf(consumerWorkerProps, s"consumer-worker-${UUID_GENERATOR.generate()}"),
+        kclWorker,
+        managerBatchTimeout,
+        consumerConf.workerConf.shutdownTimeout.duration
+      )(ctx)
+      createdProcessingManager += manager
+      manager
+    }
+
+    // test consumer are started during instantiation
+    start()
+  }
+}
+
+

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceGraphIntegrationSpec.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceGraphIntegrationSpec.scala
@@ -11,17 +11,17 @@ import org.scalatest._
 import scala.concurrent.duration._
 
 class KinesisSourceGraphIntegrationSpec
-    extends WordSpec
+    extends FreeSpec
     with KinesisSuite
     with KinesisConfiguration
     with AkkaUnitTestLike
     with Matchers {
 
-  override implicit def patienceConfig: PatienceConfig = PatienceConfig(60.seconds)
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(60.seconds, 1.second)
 
   val TestStreamNrOfMessagesPerShard: Long = 100
 
-  "A Kinesis Source" should {
+  "A Kinesis Source" - {
 
     "process all messages of a stream with one worker" in new withKinesisConfForApp("1worker") {
       val result = Kinesis

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorker.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorker.scala
@@ -141,8 +141,9 @@ object ConsumerWorker {
 
   /**
     * Handles any important shutdown requirements such as final checkpointing
+    * @param checkpointer the checkpointer to use to checkpoint current position.
     */
-  private[consumer] case object GracefulShutdown
+  private[consumer] case class GracefulShutdown(checkpointer: IRecordProcessorCheckpointer)
 
   /**
     * Tells the manager we've completed shutdown
@@ -447,7 +448,7 @@ private[consumer] class ConsumerWorker(eventProcessor: ActorRef,
         logger.warn(s"Worker for shard $latestShardId: Failed to checkpoint '$seqNo'")
       }
 
-    case GracefulShutdown => {
+    case GracefulShutdown(checkpointer) => {
       implicit val shutdownTimeout = workerConf.shutdownTimeout
       val outerSender              = sender()
 
@@ -465,7 +466,7 @@ private[consumer] class ConsumerWorker(eventProcessor: ActorRef,
 
       //Note that if this checkpoint fails (backoff, etc), we won't retry!!
       checkpoint(latestProcessedSeq) {
-        (checkpointer: IRecordProcessorCheckpointer, latestSeq: CompoundSequenceNumber) =>
+        (_: IRecordProcessorCheckpointer, latestSeq: CompoundSequenceNumber) =>
           (checkpointWorker ? Checkpoint(checkpointer, latestSeq, force = true))
             .mapTo[CheckpointResult]
       } match {

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorker.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorker.scala
@@ -448,7 +448,7 @@ private[consumer] class ConsumerWorker(eventProcessor: ActorRef,
         logger.warn(s"Worker for shard $latestShardId: Failed to checkpoint '$seqNo'")
       }
 
-    case GracefulShutdown(checkpointer) => {
+    case GracefulShutdown(shutdownCheckpointer) => {
       implicit val shutdownTimeout = workerConf.shutdownTimeout
       val outerSender              = sender()
 
@@ -467,7 +467,7 @@ private[consumer] class ConsumerWorker(eventProcessor: ActorRef,
       //Note that if this checkpoint fails (backoff, etc), we won't retry!!
       checkpoint(latestProcessedSeq) {
         (_: IRecordProcessorCheckpointer, latestSeq: CompoundSequenceNumber) =>
-          (checkpointWorker ? Checkpoint(checkpointer, latestSeq, force = true))
+          (checkpointWorker ? Checkpoint(shutdownCheckpointer, latestSeq, force = true))
             .mapTo[CheckpointResult]
       } match {
         case Some(cpResponseFut) =>

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorkerSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorkerSpec.scala
@@ -541,7 +541,7 @@ class ConsumerWorkerSpec
                                ProcessingComplete())
 
         When("We ask for a GracefulShutdown")
-        managerProbe.send(worker, GracefulShutdown)
+        managerProbe.send(worker, GracefulShutdown(checkpointer))
 
         Then("A Checkpoint is requested, forcing if necessary")
         //validate the batch gets checkpointed
@@ -577,7 +577,7 @@ class ConsumerWorkerSpec
                                       ProcessEvent(noAckRecord))
 
         When("We ask for a GracefulShutdown")
-        managerProbe.send(worker, GracefulShutdown)
+        managerProbe.send(worker, GracefulShutdown(checkpointer))
 
         Then("The manager is notified of batch completion (abort awaiting for batch response)")
         managerProbe.expectMsg(checkpointTimeout, ProcessingComplete(false))
@@ -617,7 +617,7 @@ class ConsumerWorkerSpec
                                ProcessingComplete())
 
         When("We ask for a GracefulShutdown")
-        managerProbe.send(worker, GracefulShutdown)
+        managerProbe.send(worker, GracefulShutdown(checkpointer))
 
         Then("A Checkpoint is requested, forcing if necessary")
         //validate the batch gets checkpointed
@@ -661,7 +661,7 @@ class ConsumerWorkerSpec
         checkpointerProbe.reply(CheckpointResult(event1.sequenceNumber, success = true))
 
         When("We ask for a GracefulShutdown")
-        managerProbe.send(worker, GracefulShutdown)
+        managerProbe.send(worker, GracefulShutdown(checkpointer))
 
         Then("A Checkpoint is not requested")
 


### PR DESCRIPTION
`ConsumerWorker` with related `CheckpointWorker` should be stopped on lease loss.

In case of a lost lease, KCL calls the `shutdown` method of the record processor.
Current implementation logs this call but does not react.
This change will use the graceful shutdown functionality already implemented in the ConsumerWorker for this case.

Since both methods define a checkpointer, it is used to checkpoint instead of the last used one.

I see the correct behaviour with my local manual tests.