### PR TITLE
Update KPL and KCL libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ It's worth familiarising yourself with [Sequence numbers and Sub sequence number
         * [Valid Release Tag Examples:](#contributor-guide-tag-requirements-valid-release-tag-examples)
         * [Invalid Release Tag Examples:](#contributor-guide-tag-requirements-invalid-release-tag-examples)
 * [Contribution policy](#contribution-policy)
+* [Changelog](#changelog)
 * [License](#license)
 
 
@@ -595,6 +596,10 @@ the work to the project under the project's open source license. Whether or not 
 explicitly, by submitting any copyrighted material via pull request, email, or other means you
 agree to license the material under the project's open source license and warrant that you have the
 legal authority to do so.
+
+<a name="changelog"></a>
+# Changelog
+See the releases tab: https://github.com/WW-Digital/reactive-kinesis/releases
 
 <a name="license"></a>
 # License

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val library =
       "com.fasterxml.uuid"         % "java-uuid-generator"           % "3.1.4"            % Compile)
 
     val amazon = Seq(
-      "com.amazonaws"              % "amazon-kinesis-client"         % "1.8.1"            % Compile
+      "com.amazonaws"              % "amazon-kinesis-client"         % "1.8.8"            % Compile
         excludeAll(
           ExclusionRule(organization = "com.fasterxml.jackson.core"),
           ExclusionRule(organization = "com.fasterxml.jackson.dataformat")),

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val library =
         excludeAll(
           ExclusionRule(organization = "com.fasterxml.jackson.core"),
           ExclusionRule(organization = "com.fasterxml.jackson.dataformat")),
-      "com.amazonaws"              % "amazon-kinesis-producer"       % "0.12.5"           % Compile
+      "com.amazonaws"              % "amazon-kinesis-producer"       % "0.12.8"           % Compile
         excludeAll(
           ExclusionRule(organization = "com.fasterxml.jackson.core"),
           ExclusionRule(organization = "com.fasterxml.jackson.dataformat"))

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -652,6 +652,70 @@ kinesis {
          # Default: no timeout
          #timeoutInSeconds =
 
+         # The amount of milliseconds to wait before graceful shutdown forcefully terminates the process.
+         # Default: 5000
+         #shutdownGraceMillis = 5000
+
+         # Internally support timeouts and retries for GetRecords calls.
+         #
+         # If retryGetRecordsInSeconds is set
+         # And maxGetRecordsThreadPool is set
+         # Then getRecords will asynchronously retry internally using a CompletionService of
+         # max size "maxGetRecordsThreadPool" with "retryGetRecordsInSeconds" between each retry.
+         #
+         # NOTE: this enables the AsynchronousGetRecordsRetrievalStrategy for getRecords
+         #
+         # Time in seconds to wait before the worker retries to get a record
+         # Default: Optional value, default not set
+         #retryGetRecordsInSeconds = 1
+         #
+         # max number of threads in the getRecords thread pool (per shard)
+         # Default: Optional value, default not set
+         #maxGetRecordsThreadPool = 2
+
+
+         #######################
+         # Pre-fetching config #
+         #######################
+         # Pre-fetching will retrieve and queue additional records from Kinesis while the
+         # application is processing existing records.
+         # Pre-fetching can be enabled by setting dataFetchingStrategy to PREFETCH_CACHED. Once
+         # enabled an additional fetching thread will be started to retrieve records from Kinesis.
+         # Retrieved records will be held in a queue until the application is ready to process them.
+
+         # Which data fetching strategy to use (DEFAULT, PREFETCH_CACHED)
+         # Default: DEFAULT
+         dataFetchingStrategy = PREFETCH_CACHED
+
+         #
+         # Pre-fetching supports the following configuration values:
+         #
+
+         # The maximum number of process records input that can be queued
+         # Default: 3
+         #maxPendingProcessRecordsInput = 3
+
+         # The maximum number of bytes that can be queued
+         # Default 8388608 (8 * 1024 * 1024 / 8Mb)
+         #maxCacheByteSize = 8388608
+
+         # The maximum number of records that can be queued
+         # Default: 30000
+         #maxRecordsCount = 30000
+
+         # The amount of time to wait between calls to Kinesis
+         # Default: 1500
+         #idleMillisBetweenCalls = 1500
+
+         ##############################
+         # End of Pre-fetching config #
+         ##############################
+
+
+         # Milliseconds after which the logger will log a warning message for the long running task
+         # Default: not set
+         #logWarningForTaskAfterMillis = 100
+
       }
    }
 }

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/producer/ProducerConf.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/producer/ProducerConf.scala
@@ -96,17 +96,6 @@ object ProducerConf {
       KinesisProducerConfiguration.fromProperties(kplProps)
     credentialsProvider.foreach(kplLibConfiguration.setCredentialsProvider)
 
-    //TODO, this should be part of the KPL. The KCL would handle enums and ints and let us use props directly.
-    //TODO can be removed once this is merged: https://github.com/awslabs/amazon-kinesis-producer/pull/134
-    if (kplConfig.hasPath("ThreadingModel")) {
-      kplLibConfiguration.setThreadingModel(
-        ThreadingModel.valueOf(kplConfig.getString("ThreadingModel"))
-      )
-    }
-    if (kplConfig.hasPath("ThreadPoolSize")) {
-      kplLibConfiguration.setThreadPoolSize(kplConfig.getInt("ThreadPoolSize"))
-    }
-
     kplLibConfiguration
   }
 

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerConfSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerConfSpec.scala
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2017 WeightWatchers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.weightwatchers.reactive.kinesis.consumer
+
+import java.io.File
+
+import akka.actor.ActorSystem
+import akka.testkit.{ImplicitSender, TestKit}
+import akka.util.Timeout
+import com.typesafe.config.ConfigFactory
+import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.time.{Millis, Seconds, Span}
+
+import scala.concurrent.duration.DurationInt
+
+//scalastyle:off magic.number
+class ConsumerConfSpec
+    extends TestKit(ActorSystem("consumer-conf-spec"))
+    with ImplicitSender
+    with FreeSpecLike
+    with Matchers
+    with MockitoSugar
+    with BeforeAndAfterAll
+    with GivenWhenThen
+    with ScalaFutures {
+
+  val defaultKinesisConfig =
+    ConfigFactory.parseFile(new File("src/main/resources/reference.conf")).getConfig("kinesis")
+
+  implicit val defaultPatience =
+    PatienceConfig(timeout = Span(3, Seconds), interval = Span(50, Millis))
+
+  val kinesisConfig = ConfigFactory
+    .parseString(
+      """
+        |kinesis {
+        |
+        |   application-name = "TestSpec"
+        |
+        |   test-consumer-config {
+        |      stream-name = "some-other-stream"
+        |
+        |      worker {
+        |         batchTimeoutSeconds = 1234
+        |         gracefulShutdownHook = false
+        |         shutdownTimeoutSeconds = 2
+        |      }
+        |
+        |      checkpointer {
+        |         backoffMillis = 4321
+        |      }
+        |
+        |      kcl {
+        |         AWSCredentialsProvider = DefaultAWSCredentialsProviderChain
+        |
+        |         regionName = us-east-2
+        |
+        |         # Default: LATEST
+        |         initialPositionInStream = TRIM_HORIZON
+        |
+        |         # Default = 10000
+        |         maxRecords = 20000
+        |
+        |         # Default = 1000
+        |         idleTimeBetweenReadsInMillis = 1234
+        |
+        |         # Default: 10000
+        |         failoverTimeMillis = 11000
+        |
+        |         # Default: 60000
+        |         shardSyncIntervalMillis = 70000
+        |
+        |         # Default: true
+        |         cleanupLeasesUponShardCompletion = false
+        |
+        |         # Default: true
+        |         validateSequenceNumberBeforeCheckpointing = false
+        |
+        |         # Default: null
+        |         kinesisEndpoint = "https://kinesis"
+        |
+        |         # Default: null
+        |         dynamoDBEndpoint = "https://dynamo"
+        |
+        |         # Default: false
+        |         callProcessRecordsEvenForEmptyRecordList = true
+        |
+        |         # Default: 10000
+        |         parentShardPollIntervalMillis = 40000
+        |
+        |         # Default: 500
+        |         taskBackoffTimeMillis = 600
+        |
+        |         # Default: 10000
+        |         metricsBufferTimeMillis = 10001
+        |
+        |
+        |         # Default: 10000
+        |         metricsMaxQueueSize = 10009
+        |
+        |
+        |         # Default: DETAILED
+        |         metricsLevel = NONE
+        |
+        |
+        |         # Default: Operation, ShardId
+        |         metricsEnabledDimensions = Operation
+        |
+        |
+        |         # Default: 2147483647 (Integer.MAX_VALUE)
+        |         maxLeasesForWorker = 11111111
+        |
+        |
+        |         # Default: 1
+        |         maxLeasesToStealAtOneTime = 2
+        |
+        |
+        |         # Default: 10
+        |         initialLeaseTableReadCapacity = 15
+        |
+        |
+        |         # Default: 10
+        |         initialLeaseTableWriteCapacity = 14
+        |
+        |         # Default: false
+        |         skipShardSyncAtStartupIfLeasesExist=true
+        |
+        |
+        |         # Default: <applicationName>
+        |         userAgent = testy123
+        |
+        |         # Default = <applicationName>
+        |         tableName = meh
+        |
+        |         # Default: 20
+        |         maxLeaseRenewalThreads=9
+        |
+        |
+        |         # Default: no timeout
+        |         timeoutInSeconds = 10
+        |         
+        |
+        |         # The amount of milliseconds to wait before graceful shutdown forcefully terminates.
+        |         # Default: 5000
+        |         shutdownGraceMillis = 2500
+        |
+        |         # If retryGetRecordsInSeconds is set
+        |         # And maxGetRecordsThreadPool is set
+        |         # Then use getRecords will asynchronously retry internally using a CompletionService of
+        |         # max size maxGetRecordsThreadPool with "retryGetRecordsInSeconds" between each retry
+        |         #
+        |         # Time in seconds to wait before the worker retries to get a record
+        |         # Default: Optional value, default not set
+        |         retryGetRecordsInSeconds = 2
+        |
+        |         # max number of threads in the getRecords thread pool
+        |         # Default: Optional value, default not set
+        |         maxGetRecordsThreadPool = 1
+        |         
+        |         #
+        |         # Pre-fetching config
+        |         #
+        |         
+        |         # Pre-fetching will retrieve and queue additional records from Kinesis while the
+        |         # application is processing existing records.
+        |         # Pre-fetching can be enabled by setting dataFetchingStrategy to PREFETCH_CACHED. Once
+        |         # enabled an additional fetching thread will be started to retrieve records from Kinesis. 
+        |         # Retrieved records will be held in a queue until the application is ready to process them.
+        |         
+        |         # Which data fetching strategy to use (DEFAULT, PREFETCH_CACHED)
+        |         # Default: DEFAULT
+        |         dataFetchingStrategy = DEFAULT
+        |         
+        |         #
+        |         # Pre-fetching supports the following configuration values:
+        |         #
+        |         
+        |         # The maximum number of process records input that can be queued
+        |         # Default: 3
+        |         maxPendingProcessRecordsInput = 3
+        |         
+        |         # The maximum number of bytes that can be queued
+        |         # Default 8388608 (8 * 1024 * 1024 / 8Mb)
+        |         maxCacheByteSize = 8388608
+        |         
+        |         # The maximum number of records that can be queued
+        |         # Default: 30000
+        |         maxRecordsCount = 30000
+        |         
+        |         # The amount of time to wait between calls to Kinesis
+        |         # Default: 1500
+        |         idleMillisBetweenCalls = 1500
+        |         
+        |         #
+        |         # End of Pre-fetching config
+        |         #
+        |
+        |         # Milliseconds after which the logger will log a warning message for the long running task
+        |         # Default: not set
+        |         logWarningForTaskAfterMillis = 100
+        |      }
+        |
+        |   }
+        |}
+      """.stripMargin
+    )
+    .getConfig("kinesis")
+    .withFallback(defaultKinesisConfig)
+
+  "The Consumerconf" - {
+
+    "Should parse test-consumer-config into a ConsumerConf, setting all properties in the KinesisClientLibConfiguration" in {
+      // This will fail when fields are added or renamed in the KCL
+      //
+      // The properties are automatically tested reflectively against the underlying implementation
+      // First we load each property reflectively
+      // Then we parse and try to load it from our config
+      // If it isn't present we fail the test
+
+      // We reflectively load fields, but setters are used in the implementation.
+      // However some setters don't match the field names (?!?), this renames them on the fly.
+      val confToFieldConversions = Map(
+        "skipShardSyncAtStartupIfLeasesExist" -> "skipShardSyncAtWorkerInitializationIfLeasesExist",
+        "maxCacheByteSize"                    -> "maxByteSize"
+      )
+
+      // RecordsFetcherFactory is a nested object in the configurator, so we define it's fields manually as a hack
+      val recordFetcherFields = List(
+        "maxPendingProcessRecordsInput",
+        "maxCacheByteSize",
+        "maxRecordsCount",
+        "idleMillisBetweenCalls",
+        "dataFetchingStrategy"
+      )
+
+      // Some fields dion't have setters / aren't configurable
+      val fieldsToSkip = List(
+        "useragent", //this gets nested internally
+        "streamname",
+        "timestampatinitialpositioninstream",
+        "commonclientconfig",
+        "shardprioritizationstrategy",
+        "kinesisclientconfig",
+        "dynamodbclientconfig",
+        "cloudwatchclientconfig",
+        "credentialsprovider", //these must be tested individually
+        "applicationname"
+      )
+
+      val consumerConf = ConsumerConf(kinesisConfig, "test-consumer-config")
+
+      consumerConf.workerConf.batchTimeout should be(1234.seconds)
+      consumerConf.workerConf.failedMessageRetries should be(1)
+      consumerConf.workerConf.failureTolerancePercentage should be(0.25)
+      consumerConf.workerConf.shutdownHook should be(false)
+      consumerConf.workerConf.shutdownTimeout should be(Timeout(2.seconds))
+      consumerConf.checkpointerConf.backoff should be(4321.millis)
+      consumerConf.checkpointerConf.interval should be(2000.millis)          //reference default
+      consumerConf.checkpointerConf.notificationDelay should be(1000.millis) //reference default
+      consumerConf.dispatcher should be(Some("kinesis.akka.default-dispatcher"))
+      consumerConf.kclConfiguration.getApplicationName should be(
+        "TestSpec-some-other-stream"
+      )
+
+      val kclConfig             = kinesisConfig.getConfig("test-consumer-config.kcl")
+      val kclLibConfiguration   = consumerConf.kclConfiguration
+      val recordsFetcherFactory = kclLibConfiguration.getRecordsFetcherFactory
+
+      //We're dealing with Java classes so using Java reflection is cleaner here
+      //Start with the setters to prevent picking up all the unrelated private fields, stripping the "with"
+      val configKeys = kclLibConfiguration.getClass.getDeclaredMethods
+        .filter(_.getName.startsWith("with"))
+        .map(_.getName.drop(4))
+        .map(field => field.head.toLower + field.tail)
+        .filterNot(
+          field => fieldsToSkip.contains(field.toLowerCase)
+        )
+
+      configKeys foreach { configKey =>
+        //Hack to deal with the nested objects
+        //The "with" setters live on the kclLibConfiguration, but they defer and set the value on the nested object
+        //We need to know which object to assert, so we use a pre-defined list
+        //TODO we could do this automatically if we used getFields to load all fields and traversed down, combining the lists
+        val obj =
+          if (recordFetcherFields.contains(configKey)) recordsFetcherFactory
+          else kclLibConfiguration
+
+        val field =
+          obj.getClass.getDeclaredField(
+            confToFieldConversions.getOrElse(configKey, configKey)
+          )
+        field.setAccessible(true)
+
+        withClue(
+          s"Property `$configKey` was missing or incorrect when asserting the KCL configuration - possibly a newly added KCL property: "
+          //The property should be defined in the test config above, and also in the reference.conf with full description and defaults - commented out.
+        ) {
+          kclConfig.hasPath(configKey) should be(true)
+          field.get(obj).toString should include(kclConfig.getString(configKey))
+        }
+      }
+
+    }
+  }
+}
+
+//scalastyle:on

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/producer/ProducerConfSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/producer/ProducerConfSpec.scala
@@ -211,6 +211,13 @@ class ProducerConfSpec
   "The ProducerConf" - {
 
     "Should parse the Config into a ProducerConf, setting all properties in the KinesisProducerConfiguration" in {
+      // This will fail when fields are added or renamed in the KPL
+      //
+      // The properties are automatically tested reflectively against the underlying implementation
+      // First we load each property reflectively
+      // Then we parse and try to load it from our config
+      // If it isn't present we fail the test
+
       val producerConf = ProducerConf(kinesisConfig, "testProducer")
 
       producerConf.streamName should be("core-test-kinesis-producer")
@@ -238,7 +245,7 @@ class ProducerConfSpec
         field.setAccessible(true)
 
         withClue(
-          s"Property `$configKey` was not as expected when asserting the KPL configuration: "
+          s"Property `$configKey` was missing or incorrect when asserting the KPL configuration - possibly a newly added KPL property: "
         ) {
           kplConfig.hasPath(configKey) should be(true)
           field.get(kplLibConfiguration).toString should be(kplConfig.getString(configKey))

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceGraphSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceGraphSpec.scala
@@ -36,6 +36,7 @@ import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
 import com.weightwatchers.reactive.kinesis.models.{CompoundSequenceNumber, ConsumerEvent}
 import org.joda.time.DateTime
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, Matchers}
 
 import scala.concurrent.duration._
@@ -51,6 +52,8 @@ class KinesisSourceGraphSpec
 
   implicit val materializer: Materializer = ActorMaterializer()
   implicit val ec                         = system.dispatcher
+  implicit val defaultPatience =
+    PatienceConfig(timeout = Span(3, Seconds), interval = Span(50, Millis))
 
   "KinesisSourceGraph" - {
 


### PR DESCRIPTION
**KCL: 1.8.1 -> 1.8.8**

* Support timeouts, and retry for GetRecords calls.
Applications can now use an Async retry for getRecords calls to Kinesis. In addition to setting the retryGetRecordsInSeconds timeout, the application must also provide a maxGetRecordsThreadPool size for concurrent requests.
* Support configuring the graceful shutdown timeout for MultiLang Clients using `shutdownGraceMillis`. This adds support for setting the timeout that the Java process will wait for the MutliLang client to complete graceful shutdown.
* Record pre-fetching 
  * This will retrieve and queue additional records from Kinesis while the application is processing existing records.
  * Prefetching can be enabled by setting dataFetchingStrategy to PREFETCH_CACHED. Once enabled an additional fetching thread will be started to retrieve records from Kinesis. Retrieved records will be held in a queue until the application is ready to process them.
* Logging of long running tasks can be enabled by setting the `logWarningForTaskAfterMillis` configuration property


**KPL: 0.12.5 -> 0.12.8**