### PR TITLE
Add additional factory methods to Kinesis to create Akka Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ An Akka `Source` is provided that can be used with streams. It is possible to cr
 directly from the consumer name that is defined in the configuration.
 Every message that is emitted to the stream is of type `CommitableEvent[ConsumerEvent]` and has to be committed 
 explicitly downstream with a call to `event.commit()`. It is possible to map to a different type of `CommittableEvent` 
-via the `map` and `mapAsync` functionality. 
+via the `map` and `mapAsync` functionality. A `KinesisConsumer` is created internally for the `Kinesis.source`, when the factory method isn't defined.
 
 ```scala
 import com.weightwatchers.reactive.kinesis.stream._
@@ -325,7 +325,29 @@ Kinesis
   .runWith(Sink.seq) 
 ```
 
-A `KinesisConsumer` is used internally for the `Kinesis.source`. All rules described here for the `KinesisConsumer` also apply for the stream source.
+Or you can explicitly path a lambda, to create the `KinesisConsumer`. 
+
+```scala
+import akka.actor.{ActorRef, ActorSystem}
+import akka.stream.scaladsl.Sink
+import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer
+import com.weightwatchers.reactive.kinesis.stream._
+
+val sys = ActorSystem("kinesis-consumer-system")
+
+Kinesis
+  .source(
+    "consumer-name",
+    (conf: KinesisConsumer.ConsumerConf, eventProcessor: ActorRef) => KinesisConsumer(conf, eventProcessor, sys)
+  )
+  .take(100)
+  .map(event => event.map(_.payloadAsString())) // read and map payload as string
+  .mapAsync(10)(event => event.mapAsync(Downloader.download(event.payload))) // handle an async message
+  .map(event => event.commit()) // mark the event as handled by calling commit
+  .runWith(Sink.seq)
+```
+
+All rules described here for the `KinesisConsumer` also apply for the stream source.
 
 <a name="usage-usage-consumer-graceful-shutdown"></a>
 ### Graceful Shutdown

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/stream/Kinesis.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/stream/Kinesis.scala
@@ -110,14 +110,14 @@ object Kinesis extends LazyLogging {
     * See kinesis reference.conf for a list of all available config options.
     *
     * @param consumerName the name of the consumer in the application.conf.
-    * @param inConfig the name of the sub-config for kinesis.
     * @param createConsumer factory function to create ConsumerService from eventProcessor ActorRef.
+    * @param inConfig the name of the sub-config for kinesis.
     * @param system the actor system to use.
     * @return A source of KinesisEvent objects.
     */
   def source(consumerName: String,
-             inConfig: String = "kinesis",
-             createConsumer: (ConsumerConf, ActorRef) => ConsumerService
+             createConsumer: (ConsumerConf, ActorRef) => ConsumerService,
+             inConfig: String = "kinesis"
   )(implicit system: ActorSystem): Source[CommittableEvent[ConsumerEvent], NotUsed] = {
     val consumerConf = ConsumerConf(system.settings.config.getConfig(inConfig), consumerName)
     source(consumerConf, createConsumer(consumerConf, _))

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/stream/Kinesis.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/stream/Kinesis.scala
@@ -144,7 +144,7 @@ object Kinesis extends LazyLogging {
   def source(
       consumerName: String,
       createConsumer: (ConsumerConf, ActorRef) => ConsumerService,
-      inConfig: String = "kinesis",
+      inConfig: String = "kinesis"
   )(implicit system: ActorSystem): Source[CommittableEvent[ConsumerEvent], NotUsed] = {
     val consumerConf = ConsumerConf(system.settings.config.getConfig(inConfig), consumerName)
     source(consumerConf, createConsumer(consumerConf, _))
@@ -166,9 +166,10 @@ object Kinesis extends LazyLogging {
     * @param system the actor system.
     * @return A sink that accepts ProducerEvents.
     */
-  def sink(props: => Props, maxOutStanding: Int)(
-      implicit system: ActorSystem
-  ): Sink[ProducerEvent, Future[Done]] = {
+  def sink(
+      props: => Props,
+      maxOutStanding: Int
+  )(implicit system: ActorSystem): Sink[ProducerEvent, Future[Done]] = {
     Sink.fromGraph(new KinesisSinkGraphStage(props, maxOutStanding, system))
   }
 
@@ -218,11 +219,11 @@ object Kinesis extends LazyLogging {
     * @param system the actor system.
     * @return A sink that accepts ProducerEvents.
     */
-  def sink(kinesisConfig: Config,
-           producerName: String,
-           credentialsProvider: Option[AWSCredentialsProvider])(
-      implicit system: ActorSystem
-  ): Sink[ProducerEvent, Future[Done]] = {
+  def sink(
+      kinesisConfig: Config,
+      producerName: String,
+      credentialsProvider: Option[AWSCredentialsProvider]
+  )(implicit system: ActorSystem): Sink[ProducerEvent, Future[Done]] = {
     sink(
       ProducerConf(kinesisConfig, producerName, credentialsProvider)
     )
@@ -258,11 +259,11 @@ object Kinesis extends LazyLogging {
     * @param system the actor system.
     * @return A sink that accepts ProducerEvents.
     */
-  def sink(producerName: String,
-           inConfig: String = "kinesis",
-           credentialsProvider: Option[AWSCredentialsProvider] = None)(
-      implicit system: ActorSystem
-  ): Sink[ProducerEvent, Future[Done]] = {
+  def sink(
+      producerName: String,
+      inConfig: String = "kinesis",
+      credentialsProvider: Option[AWSCredentialsProvider] = None
+  )(implicit system: ActorSystem): Sink[ProducerEvent, Future[Done]] = {
     sink(system.settings.config.getConfig(inConfig), producerName, credentialsProvider)
   }
 }

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceGraphStage.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceGraphStage.scala
@@ -143,13 +143,6 @@ class KinesisSourceGraphStage(config: ConsumerConf,
     extends GraphStage[SourceShape[CommittableEvent[ConsumerEvent]]]
     with LazyLogging {
 
-  /**
-    * Ctor that uses the KinesisConsumer as ConsumerService implementation.
-    */
-  def this(config: ConsumerConf, actorSystem: ActorSystem) = {
-    this(config, KinesisConsumer(config, _, actorSystem), actorSystem)
-  }
-
   private[this] val out: Outlet[CommittableEvent[ConsumerEvent]]   = Outlet("KinesisSource.out")
   override val shape: SourceShape[CommittableEvent[ConsumerEvent]] = SourceShape.of(out)
 


### PR DESCRIPTION
As the result of the issue with graceful shutdown of the KinesisConsumer described in https://github.com/WW-Digital/reactive-kinesis/issues/60, I added the additional methods to create the Akka Source with explicitly pathing the ConsumerService, for the better controll of the shutdown process.