### PR TITLE
upgrade localstack

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,10 +42,10 @@ lazy val library =
     val amazon = Seq(
       // TODO: Upgrade this to 1.9.x when this issue is resolved and exposed in localstack:
       // https://github.com/mhart/kinesalite/issues/59
-      "com.amazonaws" % "amazon-kinesis-client" % "1.8.10" % Compile
+      "com.amazonaws" % "amazon-kinesis-client" % "1.9.1" % Compile
       excludeAll (ExclusionRule(organization = "com.fasterxml.jackson.core"),
       ExclusionRule(organization = "com.fasterxml.jackson.dataformat")),
-      "com.amazonaws" % "amazon-kinesis-producer" % "0.12.8" % Compile
+      "com.amazonaws" % "amazon-kinesis-producer" % "0.12.9" % Compile
       excludeAll (ExclusionRule(organization = "com.fasterxml.jackson.core"),
       ExclusionRule(organization = "com.fasterxml.jackson.dataformat"))
     )

--- a/localstack/docker-compose.yml
+++ b/localstack/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.3"
 
 services:
   localstack:
-    image: markglh/initialised-localstack:0.8.3
+    image: markglh/initialised-localstack:0.8.6
     volumes:
           - ./templates:/opt/bootstrap/templates
     #network_mode: "host"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -720,6 +720,15 @@ kinesis {
          # Default: not set
          #ignoreUnexpectedChildShards = false
 
+
+         # This is the default backoff time between 2 ListShards calls when throttled.
+         # Default: 1500
+         #listShardsBackoffTimeInMillis = 1500
+
+         # This is the maximum number of times the KinesisProxy will retry to make ListShards calls on being throttled.
+         # Default: 50
+         #maxListShardsRetryAttempts = 50
+
       }
    }
 }

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerConfSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerConfSpec.scala
@@ -219,6 +219,14 @@ class ConsumerConfSpec
         |         # True if we should ignore child shards which have open parents
         |         # Default: not set
         |         ignoreUnexpectedChildShards = false
+        |
+        |         # This is the default backoff time between 2 ListShards calls when throttled.
+        |         # Default: 1500
+        |         listShardsBackoffTimeInMillis = 1500
+        |
+        |         # This is the maximum number of times the KinesisProxy will retry to make ListShards calls on being throttled.
+        |         # Default: 50
+        |         maxListShardsRetryAttempts = 50
         |      }
         |
         |   }


### PR DESCRIPTION
* Upgrade KCL to 1.9.1
* Upgrade KPL to 0.12.9
* Upgrade localstack to 0.8.6

This introduces the `listshards` api.

See:
https://github.com/awslabs/amazon-kinesis-client/blob/master/CHANGELOG.md#release-190-february-6-2018