### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 scala:
 - 2.11.11
-- 2.12.5
+- 2.12.8
 jdk:
 - oraclejdk8
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -25,8 +25,8 @@ lazy val library =
     object Version {
       val scalaCheck = "1.13.5"
       val scalaTest  = "3.0.5"
-      val jackson    = "2.9.4"
-      val akka       = "2.5.11"
+      val jackson    = "2.9.8"
+      val akka       = "2.5.19"
     }
 
     val jackson = Seq(
@@ -40,12 +40,10 @@ lazy val library =
     )
 
     val amazon = Seq(
-      // TODO: Upgrade this to 1.9.x when this issue is resolved and exposed in localstack:
-      // https://github.com/mhart/kinesalite/issues/59
-      "com.amazonaws" % "amazon-kinesis-client" % "1.8.10" % Compile
+      "com.amazonaws" % "amazon-kinesis-client" % "1.9.3" % Compile
       excludeAll (ExclusionRule(organization = "com.fasterxml.jackson.core"),
       ExclusionRule(organization = "com.fasterxml.jackson.dataformat")),
-      "com.amazonaws" % "amazon-kinesis-producer" % "0.12.8" % Compile
+      "com.amazonaws" % "amazon-kinesis-producer" % "0.12.11" % Compile
       excludeAll (ExclusionRule(organization = "com.fasterxml.jackson.core"),
       ExclusionRule(organization = "com.fasterxml.jackson.dataformat"))
     )
@@ -54,7 +52,7 @@ lazy val library =
       "com.typesafe"               % "config"         % "1.3.3"      % Compile,
       "com.typesafe.akka"          %% "akka-actor"    % Version.akka % Compile,
       "com.typesafe.akka"          %% "akka-stream"   % Version.akka % Compile,
-      "com.typesafe.scala-logging" %% "scala-logging" % "3.8.0"      % Compile
+      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0"      % Compile
     )
 
     val logback = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,10 @@ lazy val library =
     )
 
     val amazon = Seq(
-      "com.amazonaws" % "amazon-kinesis-client" % "1.9.3" % Compile
+      // TODO: Upgrade this to 1.9.x when this issue is resolved and exposed in localstack:		       "com.amazonaws" % "amazon-kinesis-client" % "1.9.3" % Compile
+      // https://github.com/mhart/kinesalite/issues/59
+      // 1.9.3 breaks KinesisSourceGraphStageIntegrationSpec and ConsumerProcessingManagerIntegrationSpec
+      "com.amazonaws" % "amazon-kinesis-client" % "1.8.10" % Compile
       excludeAll (ExclusionRule(organization = "com.fasterxml.jackson.core"),
       ExclusionRule(organization = "com.fasterxml.jackson.dataformat")),
       "com.amazonaws" % "amazon-kinesis-producer" % "0.12.11" % Compile

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val library =
     )
 
     val amazon = Seq(
-      // TODO: Upgrade this to 1.9.x when this issue is resolved and exposed in localstack:		       "com.amazonaws" % "amazon-kinesis-client" % "1.9.3" % Compile
+      // TODO: Upgrade this to 1.9.x when this issue is resolved and exposed in localstack:
       // https://github.com/mhart/kinesalite/issues/59
       // 1.9.3 breaks KinesisSourceGraphStageIntegrationSpec and ConsumerProcessingManagerIntegrationSpec
       "com.amazonaws" % "amazon-kinesis-client" % "1.8.10" % Compile

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.1
+sbt.version = 1.2.8

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerConfSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerConfSpec.scala
@@ -216,6 +216,15 @@ class ConsumerConfSpec
         |         # Default: not set
         |         logWarningForTaskAfterMillis = 100
         |
+        |         # The sleep time between two listShards calls from the proxy when throttled.
+        |         # Default: 1500
+        |         listShardsBackoffTimeInMillis = 1500
+        |
+        |
+        |         # The number of times the Proxy will retry listShards call when throttled.
+        |         # Default: 50
+        |         maxListShardsRetryAttempts = 50
+        |
         |         # True if we should ignore child shards which have open parents
         |         # Default: not set
         |         ignoreUnexpectedChildShards = false


### PR DESCRIPTION
This updates

* `sbt` 1.1.1 -> 1.2.8
* `scala` 2.12.5 -> 2.12.8
* `jackson` 2.9.4 -> 2.9.8
* `akka` 2.5.11 -> 2.5.19
* ~`amazon-kinesis-client` 1.8.10 -> 1.9.3~ (broke, reverted)
* `amazon-kinesis-producer` 0.12.8 -> 0.12.11
* `scala-logging` 3.8.0 -> 3.9.0

Note: KCL has two new fields:
* `listShardsBackoffTimeInMillis`
* `maxListShardsRetryAttempts`