### PR TITLE
Upgrade amazon-kinesis-client to 1.9.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val library =
       // TODO: Upgrade this to 1.9.x when this issue is resolved and exposed in localstack:
       // https://github.com/mhart/kinesalite/issues/59
       // 1.9.3 breaks KinesisSourceGraphStageIntegrationSpec and ConsumerProcessingManagerIntegrationSpec
-      "com.amazonaws" % "amazon-kinesis-client" % "1.8.10" % Compile
+      "com.amazonaws" % "amazon-kinesis-client" % "1.9.3" % Compile
       excludeAll (ExclusionRule(organization = "com.fasterxml.jackson.core"),
       ExclusionRule(organization = "com.fasterxml.jackson.dataformat")),
       "com.amazonaws" % "amazon-kinesis-producer" % "0.12.11" % Compile

--- a/localstack/docker-compose.yml
+++ b/localstack/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.3"
 
 services:
   localstack:
-    image: markglh/initialised-localstack:0.8.3
+    image: jannikarndt/initialised-localstack:0.9.1
     volumes:
           - ./templates:/opt/bootstrap/templates
     #network_mode: "host"


### PR DESCRIPTION
Hey @markglh! I upgrade the `amazon-kinesis-client` to `1.9.3` and ran the integration tests locally on an updated `initialised-localstack` image which uses `localstack` version `0.9.1`. That works!