### PR TITLE
Cross compile for Scala 2.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 scala:
 - 2.11.11
 - 2.12.8
+- 2.13.0
 jdk:
 - oraclejdk8
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val `reactive-kinesis` =
     .settings(
       libraryDependencies ++=
         library.jackson ++ library.amazon ++ library.lightbend ++
-        library.logback ++ library.testing
+        library.logback ++ library.testing ++ library.compat
     )
 
 // *****************************************************************************
@@ -23,10 +23,10 @@ lazy val library =
   new {
 
     object Version {
-      val scalaCheck = "1.13.5"
-      val scalaTest  = "3.0.5"
+      val scalaCheck = "1.14.0"
+      val scalaTest  = "3.0.8"
       val jackson    = "2.9.8"
-      val akka       = "2.5.19"
+      val akka       = "2.5.23"
     }
 
     val jackson = Seq(
@@ -55,7 +55,7 @@ lazy val library =
       "com.typesafe"               % "config"         % "1.3.3"      % Compile,
       "com.typesafe.akka"          %% "akka-actor"    % Version.akka % Compile,
       "com.typesafe.akka"          %% "akka-stream"   % Version.akka % Compile,
-      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0"      % Compile
+      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"      % Compile
     )
 
     val logback = Seq(
@@ -67,6 +67,10 @@ lazy val library =
       "org.scalacheck"    %% "scalacheck"   % Version.scalaCheck % "it,test",
       "com.typesafe.akka" %% "akka-testkit" % Version.akka       % "it,test",
       "org.mockito"       % "mockito-core"  % "2.16.0"           % "it,test"
+    )
+
+    val compat = Seq(
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1"
     )
   }
 
@@ -98,9 +102,7 @@ lazy val commonSettings =
       "-unchecked", // Enable additional warnings where generated code depends on assumptions.
       "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
       "-Xfatal-warnings", // Fail the compilation if there are any warnings.
-      "-Xfuture", // Turn on future language features.
       "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
-      "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
       "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
       "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
       "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
@@ -114,16 +116,21 @@ lazy val commonSettings =
       "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
       "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
       "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
-      "-Xlint:unsound-match", // Pattern match may not be typesafe.
-      "-Yno-adapted-args", // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
-      "-Ypartial-unification", // Enable partial unification in type constructor inference
       "-Ywarn-dead-code", // Warn when dead code is identified.
-      "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
-      "-Ywarn-infer-any", // Warn when a type argument is inferred to be `Any`.
-      "-Ywarn-nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
-      "-Ywarn-nullary-unit", // Warn when nullary methods return Unit.
       "-Ywarn-numeric-widen" // Warn when numerics are widened.
-    ),
+    ) ++ (if (scalaVersion.value.startsWith("2.13")) Seq()
+          else
+            Seq(
+              "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
+              "-Xlint:unsound-match", // Pattern match may not be typesafe.
+              "-Ypartial-unification", // Enable partial unification in type constructor inference
+              "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
+              "-Ywarn-infer-any", // Warn when a type argument is inferred to be `Any`.
+              "-Ywarn-nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+              "-Ywarn-nullary-unit", // Warn when nullary methods return Unit.
+              "-Xfuture", // Turn on future language features.
+              "-Yno-adapted-args" // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+            )),
     scalacOptions in (Compile, doc) ++= Seq(
       "-no-link-warnings" // Suppresses problems with Scaladoc @throws links
     ),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("com.lucidchart"    % "sbt-scalafmt" % "1.15")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"      % "0.9.3")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.0.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1" exclude("org.eclipse.jgit", "org.eclipse.jgit"))
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0" exclude("org.eclipse.jgit", "org.eclipse.jgit"))
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.2" exclude("org.eclipse.jgit", "org.eclipse.jgit"))
 
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.3")

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/KinesisProducerIntegrationSpec.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/KinesisProducerIntegrationSpec.scala
@@ -29,7 +29,7 @@ import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
 import com.weightwatchers.reactive.kinesis.models.ProducerEvent
 import com.weightwatchers.reactive.kinesis.producer.{KinesisProducer, ProducerConf}
 import org.scalatest.concurrent.Eventually
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
 

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/SimpleKinesisConsumer.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/SimpleKinesisConsumer.scala
@@ -165,7 +165,7 @@ class SimpleKinesisConsumer(kinesisConfig: Config) extends Actor with LazyLoggin
 
   //scalastyle:on
 
-  private def isHealthy(expectedNum: Int, section: Seq[Int]): Boolean = {
+  private def isHealthy(expectedNum: Int, section: Iterable[Int]): Boolean = {
     val expectedRange: Iterator[Int]      = Range(totalVerified, totalVerified + expectedNum).iterator
     val actualSortedResult: Iterator[Int] = section.iterator
     def compare(actual: Iterator[Int], expected: Iterator[Int]): Boolean = {

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/common/KinesisSuite.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/common/KinesisSuite.scala
@@ -18,7 +18,7 @@ import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
 import com.weightwatchers.reactive.kinesis.producer.ProducerConf
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Suite}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 
 /**
@@ -234,7 +234,7 @@ trait KinesisSuite
     val manager = new LeaseManager[KinesisClientLease](s"$applicationName-$TestStreamName",
                                                        dynamoClient,
                                                        new KinesisClientLeaseSerializer())
-    manager.createLeaseTableIfNotExists(1l, 1l)
+    manager.createLeaseTableIfNotExists(1L, 1L)
     while (!manager.leaseTableExists()) Thread.sleep(100)
   }
 
@@ -281,8 +281,6 @@ trait KinesisSuite
   }
 
   protected def createTestData(testDataCount: Int): Unit = {
-    import scala.collection.JavaConverters._
-
     kinesisClient
       .describeStream(TestStreamName)
       .getStreamDescription

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/common/KinesisTestConsumer.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/common/KinesisTestConsumer.scala
@@ -10,7 +10,7 @@ import com.amazonaws.services.kinesis.model._
 import com.amazonaws.services.kinesis.{AmazonKinesisAsyncClient, _}
 import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.FiniteDuration
 
 object KinesisTestConsumer {

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManagerIntegrationSpec.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManagerIntegrationSpec.scala
@@ -28,7 +28,7 @@ class ConsumerProcessingManagerIntegrationSpec
 
   override def TestStreamNrOfMessagesPerShard: Long    = 0
   override def TestStreamNumberOfShards: Long          = 2
-  override implicit def patienceConfig: PatienceConfig = PatienceConfig(60.seconds, 1.second)
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(90.seconds, 1.second)
 
   "A ConsumerProcessingManager on a stream with 2 shards" - {
 

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManager.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManager.scala
@@ -38,10 +38,10 @@ import com.weightwatchers.reactive.kinesis.consumer.ConsumerWorker.{
 import com.weightwatchers.reactive.kinesis.models.{CompoundSequenceNumber, ConsumerEvent}
 import org.joda.time.{DateTime, DateTimeZone}
 
-import scala.collection.JavaConverters._
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Try
+import scala.jdk.CollectionConverters._
 
 /**
   * Manages the processing of messages for a SPECIFIC SHARD.
@@ -100,7 +100,7 @@ private[consumer] class ConsumerProcessingManager(
       // Process records and perform all exception handling.
       val allRecordsProcessedFut: Future[ProcessingComplete] =
         (consumerWorker ? ProcessEvents(
-          processRecordsInput.getRecords.asScala.map(toConsumerEvent),
+          processRecordsInput.getRecords.asScala.map(toConsumerEvent).toSeq,
           processRecordsInput.getCheckpointer,
           kinesisShardId
         )).mapTo[ProcessingComplete]

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/producer/KinesisProducerActor.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/producer/KinesisProducerActor.scala
@@ -172,7 +172,7 @@ class KinesisProducerActor(producer: KinesisProducer, throttlingConfig: Option[T
         .recover {
           case ex: UserRecordFailedException =>
             //TODO is this too much log output on error? I'm assuming this will be rare!
-            import scala.collection.JavaConverters._
+            import scala.jdk.CollectionConverters._
             val errorList = ex.getResult.getAttempts.asScala.map(attempt => s"""
                  |Delay after prev attempt: ${attempt.getDelay} ms,
                  |Duration: ${attempt.getDuration} ms, Code: ${attempt.getErrorCode},

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/utils/TypesafeConfigExtensions.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/utils/TypesafeConfigExtensions.scala
@@ -20,7 +20,7 @@ import java.util.Properties
 
 import com.typesafe.config.Config
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
   * Extensions added to Typesafe config class.

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/CheckpointWorkerSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/CheckpointWorkerSpec.scala
@@ -25,7 +25,7 @@ import com.weightwatchers.reactive.kinesis.consumer.CheckpointWorker._
 import com.weightwatchers.reactive.kinesis.models.CompoundSequenceNumber
 import com.weightwatchers.reactive.kinesis.consumer.CheckpointWorker.ReadyToCheckpoint
 import org.mockito.Mockito
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, Matchers}
 
 import scala.concurrent.Await

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerConfSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerConfSpec.scala
@@ -25,7 +25,7 @@ import com.typesafe.config.ConfigFactory
 import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Seconds, Span}
 
 import scala.concurrent.duration.DurationInt
@@ -301,7 +301,7 @@ class ConsumerConfSpec
       val configKeys = kclLibConfiguration.getClass.getDeclaredMethods
         .filter(_.getName.startsWith("with"))
         .map(_.getName.drop(4))
-        .map(field => field.head.toLower + field.tail)
+        .map(field => s"${field.head.toLower}${field.tail}")
         .filterNot(
           field => fieldsToSkip.contains(field.toLowerCase)
         )

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManagerSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManagerSpec.scala
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.util.Date
 
+import scala.jdk.CollectionConverters._
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.TestActor.AutoPilot
 import akka.testkit.{ImplicitSender, TestActor, TestDuration, TestKit, TestProbe}
@@ -39,12 +40,10 @@ import com.weightwatchers.reactive.kinesis.models.{CompoundSequenceNumber, Consu
 import org.joda.time.{DateTime, DateTimeZone}
 import org.mockito.Mockito
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, Matchers}
+import org.scalatestplus.mockito.MockitoSugar
 
-import scala.collection.JavaConverters._
-import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.{DurationDouble, FiniteDuration}
 import scala.concurrent.{Await, Future, Promise}
@@ -119,12 +118,12 @@ class ConsumerProcessingManagerSpec
 
         //validate the probe received the Seq of ConsumerEvents
         val expectedMsg = ProcessEvents(
-          ArrayBuffer(toConsumerEvent(record1),
-                      toConsumerEvent(record2),
-                      toConsumerEvent(record3),
-                      toConsumerEvent(record4),
-                      toConsumerEvent(record5),
-                      toConsumerEvent(record6)),
+          Seq(toConsumerEvent(record1),
+              toConsumerEvent(record2),
+              toConsumerEvent(record3),
+              toConsumerEvent(record4),
+              toConsumerEvent(record5),
+              toConsumerEvent(record6)),
           checkpointer,
           shardId
         )

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorkerSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorkerSpec.scala
@@ -31,7 +31,7 @@ import com.weightwatchers.reactive.kinesis.consumer.CheckpointWorker.{
 import com.weightwatchers.reactive.kinesis.consumer.ConsumerWorker._
 import com.weightwatchers.reactive.kinesis.models.{CompoundSequenceNumber, ConsumerEvent}
 import org.joda.time.DateTime
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, GivenWhenThen, Matchers}
 
 import scala.concurrent.Await

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/KinesisConsumerSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/KinesisConsumerSpec.scala
@@ -35,7 +35,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Seconds, Span}
 
 import scala.concurrent.duration.DurationInt

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/models/ConsumerEventSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/models/ConsumerEventSpec.scala
@@ -21,10 +21,10 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 import org.joda.time.DateTime
 import org.scalacheck.Gen
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{FreeSpec, Matchers}
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class ConsumerEventSpec extends FreeSpec with Matchers with GeneratorDrivenPropertyChecks {
+class ConsumerEventSpec extends FreeSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
   "A ConsumerEvent" - {
     "can be read as string" in {

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/producer/KinesisProducerActorSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/producer/KinesisProducerActorSpec.scala
@@ -23,7 +23,7 @@ import com.amazonaws.services.kinesis.producer.{UserRecordFailedException, UserR
 import com.weightwatchers.reactive.kinesis.models.ProducerEvent
 import com.weightwatchers.reactive.kinesis.producer.KinesisProducerActor._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, Matchers}
 
 import scala.concurrent.duration._

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/producer/KinesisProducerSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/producer/KinesisProducerSpec.scala
@@ -27,7 +27,7 @@ import com.typesafe.config.ConfigFactory
 import com.weightwatchers.reactive.kinesis.models.ProducerEvent
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
 
 import scala.concurrent.Future

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/producer/ProducerConfSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/producer/ProducerConfSpec.scala
@@ -33,7 +33,7 @@ import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration.Thre
 import com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension
 import com.typesafe.config.ConfigFactory
 import org.apache.http.client.CredentialsProvider
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, Matchers}
 
 import scala.concurrent.Await
@@ -253,7 +253,9 @@ class ProducerConfSpec
 
       configKeys foreach { configKey =>
         val field =
-          kplLibConfiguration.getClass.getDeclaredField(configKey.head.toLower + configKey.tail)
+          kplLibConfiguration.getClass.getDeclaredField(
+            s"${configKey.head.toLower}${configKey.tail}"
+          )
         field.setAccessible(true)
 
         withClue(

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/utils/ScalaListenableFutureSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/utils/ScalaListenableFutureSpec.scala
@@ -18,7 +18,7 @@ package com.weightwatchers.reactive.kinesis.utils
 
 import com.google.common.util.concurrent.SettableFuture
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
 
 /**

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/utils/TypesafeConfigExtensionsSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/utils/TypesafeConfigExtensionsSpec.scala
@@ -17,7 +17,7 @@
 package com.weightwatchers.reactive.kinesis.utils
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
 
 /**


### PR DESCRIPTION
- add scala-collection-compat to cover JavaConverters deprecation
- update various dependencies to the new one that supports 2.13
- conditionally include some of the removed compiler flags
- add 2.13 to travis.yml