### PR TITLE
Kinesis Retries scheme for KPL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ scala:
 - 2.11.11
 - 2.12.8
 jdk:
-- oraclejdk8
+- openjdk8
 cache:
   directories:
   - "$HOME/.m2/repository"

--- a/README.md
+++ b/README.md
@@ -496,6 +496,30 @@ class SomeActor(kinesisConfig: Config) extends Actor {
 }
 ```
 
+#### Scheme for kinesis retries in services
+
+Kinesis Retry model with service DB:
+<ul>
+<li>The service itself manage their kinesis failures.</li>
+<li>Practical, develop only in service.</li>
+<li>Save time for learning and integration with other technology.</li>
+</ul>
+ Algorithm steps to publish event to stream:
+
+```
+if sendSuccessful
+    continue
+if sendFiled
+    save event in db
+if backgroundJob.connect(stream).isSuccessful
+    go to step1
+    delete event from DB 
+else
+    do nothing.
+```
+
+https://www.lucidchart.com/invitations/accept/6522abde-92bd-4b60-ba74-76881b7f807b
+
 <a name="usage-usage-producer-actor-based-implementation-from-outside-of-an-actor"></a>
 #### From outside of an Actor
 

--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ else
     do nothing.
 ```
 
-https://www.lucidchart.com/invitations/accept/6522abde-92bd-4b60-ba74-76881b7f807b
+![Kinesis retries diagram scheme](https://www.lucidchart.com/publicSegments/view/e9674455-b544-4634-a29c-7066c32ddc45/image.png)
 
 <a name="usage-usage-producer-actor-based-implementation-from-outside-of-an-actor"></a>
 #### From outside of an Actor

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/SimpleKinesisProducer.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/SimpleKinesisProducer.scala
@@ -146,9 +146,9 @@ class SimpleKinesisProducer(kConfig: Config) extends Actor with LazyLogging {
       logger.trace(s"Successfully sent $messageId")
       outstandingMessages -= messageId
 
-    case SendFailed(messageId, reason) =>
+    case SendFailed(event, messageId, reason) =>
       val failedPayload = outstandingMessages(messageId)
-      logger.info(s"""Failed to send ProducerEvent($messageId, $failedPayload""".stripMargin)
+      logger.info(s"""Failed to send ProducerEvent(${event.partitionKey}, $messageId) for $failedPayload""".stripMargin)
       outstandingMessages -= messageId
       failedMessages += (messageId, failedPayload)
   }

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/producer/KinesisProducerActor.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/producer/KinesisProducerActor.scala
@@ -56,11 +56,11 @@ object KinesisProducerActor {
   /**
     * Sent to the sender in event of a failed completion.
     *
-    * @param messageId The id of the event that failed.
+    * @param event     The current event that failed.
     * @param reason    The exception causing the failure.
     *                  Likely to be of type [[com.amazonaws.services.kinesis.producer.UserRecordFailedException]]
     */
-  case class SendFailed(messageId: String, reason: Throwable)
+  case class SendFailed(event: ProducerEvent, reason: Throwable)
 
   private case object UnThrottle
 
@@ -182,10 +182,11 @@ class KinesisProducerActor(producer: KinesisProducer, throttlingConfig: Option[T
               s"Record failed to put, partitionKey=${event.partitionKey}, payload=${event.payload}, attempts:$errorList",
               ex
             )
-            SendFailed(messageId, ex)
+            val evento: ProducerEvent = event
+            SendFailed(event, ex)
           case ex =>
             logger.warn(s"Failed to send message to kinesis with: $event", ex)
-            SendFailed(messageId, ex)
+            SendFailed(event, ex)
         }
         .pipeTo(sender)
     }

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSinkGraphStage.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSinkGraphStage.scala
@@ -135,8 +135,11 @@ class KinesisSinkGraphStage(producerActorProps: => Props,
             if (outstandingMessageCount < maxOutstanding) pull(in)
           }
 
-        case (_, SendFailed(messageId, reason)) =>
-          logger.warn(s"Could not send message with id: $messageId", reason)
+        case (_, SendFailed(event, messageId, reason)) =>
+          logger.warn(
+            s"Could not send message with id $messageId and partitionKey ${event.partitionKey}",
+            reason
+          )
           failStage(reason)
 
         case (_, Terminated(_)) =>

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/producer/KinesisProducerActorSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/producer/KinesisProducerActorSpec.scala
@@ -114,7 +114,7 @@ class KinesisProducerActorSpec
       producerActor.tell(msg, probe.ref)
 
       //Then we should receive a SendSuccessful response
-      probe.expectMsg(SendFailed(msg.messageId, ex))
+      probe.expectMsg(SendFailed(event, msg.messageId, ex))
       verify(producer, times(1)).addUserRecord(event)
     }
 

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSinkGraphStageSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSinkGraphStageSpec.scala
@@ -125,7 +125,7 @@ class KinesisSinkGraphStageSpec
   }
 
   def failMessage(sender: ActorRef, event: SendWithCallback): Unit = {
-    sender ! SendFailed(event.messageId, new IllegalStateException("wrong!"))
+    sender ! SendFailed(event.producerEvent, event.messageId, new IllegalStateException("wrong!"))
   }
 
   def ignoreMessage(sender: ActorRef, event: SendWithCallback): Unit = ()


### PR DESCRIPTION
# Overview
- Added kinesis retries scheme.

 # Design/Changes
- Modify to add ProducerEvent to SendFailed class to return event published that failed, because in order to implement retries for kinesis eventing model, we need the same event published before in the context of the actor that receive the SendFailed event in return.
- Scheme to be implement:

![Kinesis retries diagram scheme](https://www.lucidchart.com/publicSegments/view/e9674455-b544-4634-a29c-7066c32ddc45/image.png)